### PR TITLE
Auth guard over pages under base page

### DIFF
--- a/main/views.py
+++ b/main/views.py
@@ -1,5 +1,9 @@
 from django.views.generic import TemplateView
+from django.contrib.auth.decorators import login_required
+from django.utils.decorators import method_decorator
 
 
+
+@method_decorator(login_required(login_url='/accounts/log-in'), name='dispatch')
 class IndexPageView(TemplateView):
-    template_name = 'main/index.html'
+    template_name = 'layouts/default/page.html'


### PR DESCRIPTION
This PR guards the pages which extend the base page from rendering thier content without being logged in into the platform
Fix #66 